### PR TITLE
Add Maven central and SonarCloud badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Axon Framework - Reactor Extension [![Build Status](https://travis-ci.org/AxonFramework/extension-reactor.svg?branch=master)](https://travis-ci.org/AxonFramework/extension-reactor)
+# Axon Framework - Reactor Extension 
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.axonframework.extensions.reactor/axon-reactor/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.axonframework.extensions.reactor/axon-reactor/)
+[![Build Status](https://travis-ci.org/AxonFramework/extension-reactor.svg?branch=master)](https://travis-ci.org/AxonFramework/extension-reactor)
+[![SonarCloud Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AxonFramework_extension-reactor&metric=alert_status)](https://sonarcloud.io/dashboard?id=AxonFramework_extension-reactor)
 
 Axon Framework is a framework for building evolutionary, event-driven microservice systems,
  based on the principles of Domain Driven Design, Command-Query Responsibility Segregation (CQRS) and Event Sourcing.
@@ -52,4 +56,3 @@ When filing features:
 * (Pseudo-)Code snippets showing what it might look like help us understand your suggestion better 
 * If you have any thoughts on where to plug this into the framework, that would be very helpful too
 * Lastly, we value contributions to the framework highly. So please provide a Pull Request as well!
- 


### PR DESCRIPTION
This PR will add Maven central and SonarCloud badges.

Maven central badge points to the main `axon-reactor` coordinates