### PR TITLE
Fix gateways builder

### DIFF
--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGateway.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGateway.java
@@ -232,7 +232,7 @@ public class DefaultReactorCommandGateway implements ReactorCommandGateway {
          */
         public Builder resultHandlerInterceptors(
                 List<ReactorResultHandlerInterceptor<CommandMessage<?>, CommandResultMessage<?>>> resultHandlerInterceptors) {
-            this.resultInterceptors = resultHandlerInterceptors != null && resultHandlerInterceptors.isEmpty()
+            this.resultInterceptors = resultHandlerInterceptors != null && !resultHandlerInterceptors.isEmpty()
                     ? new CopyOnWriteArrayList<>(resultHandlerInterceptors)
                     : new CopyOnWriteArrayList<>();
             return this;

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/queryhandling/gateway/DefaultReactorQueryGateway.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/queryhandling/gateway/DefaultReactorQueryGateway.java
@@ -258,7 +258,7 @@ public class DefaultReactorQueryGateway implements ReactorQueryGateway {
          */
         public Builder dispatchInterceptors(
                 List<ReactorMessageDispatchInterceptor<QueryMessage<?, ?>>> dispatchInterceptors) {
-            this.dispatchInterceptors = dispatchInterceptors != null && dispatchInterceptors.isEmpty()
+            this.dispatchInterceptors = dispatchInterceptors != null && !dispatchInterceptors.isEmpty()
                     ? new CopyOnWriteArrayList<>(dispatchInterceptors)
                     : new CopyOnWriteArrayList<>();
             return this;

--- a/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGatewayTest.java
+++ b/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGatewayTest.java
@@ -80,6 +80,21 @@ class DefaultReactorCommandGatewayTest {
     }
 
     @Test
+    void testBuilderResultFiltering() {
+        ReactorCommandGateway reactorCommandGateway = DefaultReactorCommandGateway.builder()
+                .commandBus(commandBus)
+                .resultHandlerInterceptors((message, results) -> results.filter(result -> result.getMetaData().containsKey("K")))
+                .build();
+        // int 1 -> flux of results is filtered
+
+        Mono<CommandResultMessage<?>> results = reactorCommandGateway.send("");
+        StepVerifier.create(results)
+                .verifyComplete();
+        // verify -> command has been sent
+        assertEquals(1, commandBus.numberOfSentCommands());
+    }
+
+    @Test
     void testCommandFiltering() {
         registerMessageFilter(gateway, result -> result.getMetaData().containsKey("K"));
         // int 1 -> flux of results is filtered

--- a/axon-reactor/src/test/java/org/axonframework/extensions/reactor/queryhandling/gateway/DefaultReactorQueryGatewayTest.java
+++ b/axon-reactor/src/test/java/org/axonframework/extensions/reactor/queryhandling/gateway/DefaultReactorQueryGatewayTest.java
@@ -238,6 +238,18 @@ class DefaultReactorQueryGatewayTest {
     }
 
     @Test
+    void testQueryWithBuilderDispatchInterceptor() {
+        ReactorQueryGateway reactorQueryGateway = DefaultReactorQueryGateway.builder()
+                .queryBus(queryBus)
+                .dispatchInterceptors(queryMono -> queryMono.map(query -> query.andMetaData(Collections.singletonMap("key1", "value1"))))
+                .build();
+
+        StepVerifier.create(reactorQueryGateway.query(true, String.class))
+                .expectNext("value1")
+                .verifyComplete();
+    }
+
+    @Test
     void testQueryWithErrorDispatchInterceptor() {
         reactiveQueryGateway
                 .registerResultHandlerInterceptor((q,r) -> r.onErrorMap(t-> new MockException()));


### PR DESCRIPTION
When creating a `DefaultReactorQueryGateway `using its Builder, the Dispatch Interceptors are not registered. The same happens with the `DefaultReactorCommandGateway `and Result Handler Interceptors. This PR fixes both.