### PR TITLE
Reactor core upgrade

### DIFF
--- a/axon-reactor-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/reactor/autoconfig/ReactorAutoConfiguration.java
+++ b/axon-reactor-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/reactor/autoconfig/ReactorAutoConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.autoconfig;
 
 import org.axonframework.commandhandling.CommandBus;

--- a/axon-reactor-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/reactor/autoconfig/ReactorAutoConfigurationTest.java
+++ b/axon-reactor-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/reactor/autoconfig/ReactorAutoConfigurationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.autoconfig;
 
 import org.axonframework.commandhandling.CommandBus;
@@ -63,6 +79,7 @@ class ReactorAutoConfigurationTest {
 
     @Configuration
     public static class Context {
+
         @Bean
         public CommandBus commandBus() {
             return SimpleCommandBus.builder().build();

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/commandhandling/callbacks/ReactorCallback.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/commandhandling/callbacks/ReactorCallback.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.commandhandling.callbacks;
 
 import org.axonframework.commandhandling.CommandCallback;
@@ -36,5 +52,4 @@ public class ReactorCallback<C, R> extends Mono<CommandResultMessage<? extends R
     public void subscribe(CoreSubscriber<? super CommandResultMessage<? extends R>> actual) {
         commandResultMessageEmitter.subscribe(actual);
     }
-
 }

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGateway.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGateway.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.commandhandling.gateway;
 
 import org.axonframework.commandhandling.*;
@@ -79,9 +95,9 @@ public class DefaultReactorCommandGateway implements ReactorCommandGateway {
 
     private Mono<CommandMessage<?>> createCommandMessage(Object command) {
         return Mono.just(command)
-                .transformDeferredContextual((commandMono, contextView) ->
-                        commandMono.map(c -> GenericCommandMessage.asCommandMessage(c)
-                                .andMetaData(metaDataFromContext(contextView))));
+                   .transformDeferredContextual((commandMono, contextView) ->
+                                                        commandMono.map(c -> GenericCommandMessage.asCommandMessage(c)
+                                                                                                  .andMetaData(metaDataFromContext(contextView))));
     }
 
     private MetaData metaDataFromContext(ContextView contextView) {
@@ -103,8 +119,8 @@ public class DefaultReactorCommandGateway implements ReactorCommandGateway {
 
     private Mono<CommandMessage<?>> processCommandInterceptors(Mono<CommandMessage<?>> commandMessage) {
         return Flux.fromIterable(dispatchInterceptors)
-                .reduce(commandMessage, (command, interceptor) -> interceptor.intercept(command))
-                .flatMap(Function.identity());
+                   .reduce(commandMessage, (command, interceptor) -> interceptor.intercept(command))
+                   .flatMap(Function.identity());
     }
 
     private <C, R> Mono<Tuple2<CommandMessage<C>, Flux<CommandResultMessage<? extends R>>>> dispatchCommand(
@@ -124,12 +140,12 @@ public class DefaultReactorCommandGateway implements ReactorCommandGateway {
             Tuple2<CommandMessage<C>, Flux<CommandResultMessage<?>>> commandWithResults) {
         CommandMessage<?> commandMessage = commandWithResults.getT1();
         Flux<CommandResultMessage<?>> commandResultMessages = commandWithResults.getT2()
-                .flatMapSequential(this::mapExceptionalResult);
+                                                                                .flatMapSequential(this::mapExceptionalResult);
 
         return Flux.fromIterable(resultInterceptors)
-                .reduce(commandResultMessages,
-                        (result, interceptor) -> interceptor.intercept(commandMessage, result))
-                .flatMap(Flux::next); // command handlers provide only one result!
+                   .reduce(commandResultMessages,
+                           (result, interceptor) -> interceptor.intercept(commandMessage, result))
+                   .flatMap(Flux::next); // command handlers provide only one result!
     }
 
     private <R> Mono<R> getPayload(Mono<? extends CommandResultMessage<?>> commandResultMessage) {

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/commandhandling/gateway/ReactorCommandGateway.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/commandhandling/gateway/ReactorCommandGateway.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.commandhandling.gateway;
 
 import org.axonframework.commandhandling.CommandBus;
@@ -51,5 +67,4 @@ public interface ReactorCommandGateway extends ReactorMessageDispatchInterceptor
         return Flux.from(commands)
                    .concatMap(this::send);
     }
-
 }

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/eventhandling/gateway/DefaultReactorEventGateway.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/eventhandling/gateway/DefaultReactorEventGateway.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.eventhandling.gateway;
 
 import org.axonframework.common.AxonConfigurationException;
@@ -67,11 +83,10 @@ public class DefaultReactorEventGateway implements ReactorEventGateway {
 
     private Mono<EventMessage<?>> createEventMessage(Object event) {
         return Mono.just(event)
-                .transformDeferredContextual((eventMono,contextView) ->
-                        eventMono.map(ev -> GenericEventMessage.asEventMessage(ev)
-                                .andMetaData(metaDataFromContext(contextView))
-                        ));
-
+                   .transformDeferredContextual((eventMono,contextView) ->
+                                                        eventMono.map(ev -> GenericEventMessage.asEventMessage(ev)
+                                                                                               .andMetaData(metaDataFromContext(contextView))
+                                                        ));
     }
 
     private MetaData metaDataFromContext(ContextView contextView) {

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/eventhandling/gateway/ReactorEventGateway.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/eventhandling/gateway/ReactorEventGateway.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.eventhandling.gateway;
 
 import org.axonframework.eventhandling.EventBus;

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/messaging/ReactorMessageDispatchInterceptor.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/messaging/ReactorMessageDispatchInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.messaging;
 
 import org.axonframework.messaging.Message;

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/messaging/ReactorMessageDispatchInterceptorSupport.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/messaging/ReactorMessageDispatchInterceptorSupport.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.messaging;
 
 import org.axonframework.common.Registration;

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/messaging/ReactorResultHandlerInterceptor.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/messaging/ReactorResultHandlerInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.messaging;
 
 import org.axonframework.messaging.Message;

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/messaging/ReactorResultHandlerInterceptorSupport.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/messaging/ReactorResultHandlerInterceptorSupport.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.messaging;
 
 import org.axonframework.common.Registration;

--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/queryhandling/gateway/ReactorQueryGateway.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/queryhandling/gateway/ReactorQueryGateway.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.queryhandling.gateway;
 
 import org.axonframework.extensions.reactor.messaging.ReactorMessageDispatchInterceptorSupport;

--- a/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/CommandBusStub.java
+++ b/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/CommandBusStub.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.commandhandling;
 
 import org.axonframework.commandhandling.CommandBus;

--- a/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/callbacks/ReactorCallbackTest.java
+++ b/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/callbacks/ReactorCallbackTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.commandhandling.callbacks;
 
 import org.axonframework.commandhandling.CommandBus;

--- a/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGatewayComponentTest.java
+++ b/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGatewayComponentTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.commandhandling.gateway;
 
 import org.axonframework.commandhandling.AsynchronousCommandBus;
@@ -132,7 +148,7 @@ class DefaultReactorCommandGatewayComponentTest {
 
         ArgumentCaptor<CommandMessage> commandMessageCaptor =  ArgumentCaptor.forClass(CommandMessage.class);
 
-        
+
         verify(commandBus).dispatch(commandMessageCaptor.capture(),any());
         CommandMessage commandMessage = commandMessageCaptor.getValue();
 

--- a/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGatewayTest.java
+++ b/axon-reactor/src/test/java/org/axonframework/extensions/reactor/commandhandling/gateway/DefaultReactorCommandGatewayTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.commandhandling.gateway;
 
 import org.axonframework.commandhandling.CommandMessage;
@@ -82,14 +98,14 @@ class DefaultReactorCommandGatewayTest {
     @Test
     void testBuilderResultFiltering() {
         ReactorCommandGateway reactorCommandGateway = DefaultReactorCommandGateway.builder()
-                .commandBus(commandBus)
-                .resultHandlerInterceptors((message, results) -> results.filter(result -> result.getMetaData().containsKey("K")))
-                .build();
+                                                                                  .commandBus(commandBus)
+                                                                                  .resultHandlerInterceptors((message, results) -> results.filter(result -> result.getMetaData().containsKey("K")))
+                                                                                  .build();
         // int 1 -> flux of results is filtered
 
         Mono<CommandResultMessage<?>> results = reactorCommandGateway.send("");
         StepVerifier.create(results)
-                .verifyComplete();
+                    .verifyComplete();
         // verify -> command has been sent
         assertEquals(1, commandBus.numberOfSentCommands());
     }
@@ -180,10 +196,10 @@ class DefaultReactorCommandGatewayTest {
     @Test
     void testResultOnErrorMapping() {
         commandBus = new CommandBusStub(GenericCommandResultMessage
-                .asCommandResultMessage(new RuntimeException("oops")));
+                                                .asCommandResultMessage(new RuntimeException("oops")));
         gateway = DefaultReactorCommandGateway.builder()
-                .commandBus(commandBus)
-                .build();
+                                              .commandBus(commandBus)
+                                              .build();
 
         gateway.registerResultHandlerInterceptor((command, results) -> results
                 .onErrorMap(t -> new MockException()));
@@ -191,8 +207,8 @@ class DefaultReactorCommandGatewayTest {
         Mono<String> result = gateway.send("");
 
         StepVerifier.create(result)
-                .expectError(MockException.class)
-                .verify();
+                    .expectError(MockException.class)
+                    .verify();
     }
 
     @Test

--- a/axon-reactor/src/test/java/org/axonframework/extensions/reactor/eventhandling/gateway/DefaultReactorEventGatewayTest.java
+++ b/axon-reactor/src/test/java/org/axonframework/extensions/reactor/eventhandling/gateway/DefaultReactorEventGatewayTest.java
@@ -62,9 +62,9 @@ class DefaultReactorEventGatewayTest {
         Context context = of(MetaData.class, MetaData.with("k","v"));
 
         Flux<String> result = gateway.publish("event")
-                .map(Message::getPayload)
-                .cast(String.class)
-                .subscriberContext(context);
+                                     .map(Message::getPayload)
+                                     .cast(String.class)
+                                     .contextWrite(c -> context);
 
         StepVerifier.create(result)
                 .expectNext("event")

--- a/axon-reactor/src/test/java/org/axonframework/extensions/reactor/eventhandling/gateway/DefaultReactorEventGatewayTest.java
+++ b/axon-reactor/src/test/java/org/axonframework/extensions/reactor/eventhandling/gateway/DefaultReactorEventGatewayTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.eventhandling.gateway;
 
 import org.axonframework.eventhandling.EventBus;
@@ -67,11 +83,11 @@ class DefaultReactorEventGatewayTest {
                                      .contextWrite(c -> context);
 
         StepVerifier.create(result)
-                .expectNext("event")
-                .expectAccessibleContext()
-                .containsOnly(context)
-                .then()
-                .verifyComplete();
+                    .expectNext("event")
+                    .expectAccessibleContext()
+                    .containsOnly(context)
+                    .then()
+                    .verifyComplete();
 
 
         ArgumentCaptor<GenericEventMessage> eventMessageCaptor =  ArgumentCaptor.forClass(GenericEventMessage.class);
@@ -82,7 +98,6 @@ class DefaultReactorEventGatewayTest {
 
         assertTrue(eventMessage.getMetaData().containsKey("k"));
         assertTrue(eventMessage.getMetaData().containsValue("v"));
-
     }
 
     @Test

--- a/axon-reactor/src/test/java/org/axonframework/extensions/reactor/queryhandling/gateway/DefaultReactorQueryGatewayTest.java
+++ b/axon-reactor/src/test/java/org/axonframework/extensions/reactor/queryhandling/gateway/DefaultReactorQueryGatewayTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.reactor.queryhandling.gateway;
 
 import org.axonframework.common.Registration;
@@ -109,19 +125,19 @@ class DefaultReactorQueryGatewayTest {
         queryBus.subscribe(Long.class.getName(), Long.class, queryMessageHandler4);
 
         queryBus.subscribe(Boolean.class.getName(),
-                String.class,
-                message -> "" + message.getMetaData().getOrDefault("key1", "")
-                        + message.getMetaData().getOrDefault("key2", ""));
+                           String.class,
+                           message -> "" + message.getMetaData().getOrDefault("key1", "")
+                                   + message.getMetaData().getOrDefault("key2", ""));
 
         queryBus.subscribe(Long.class.getName(), String.class, message -> null);
 
         queryBus.subscribe(Double.class.getName(),
-                methodOf(this.getClass(), "stringListQueryHandler").getGenericReturnType(),
-                message -> Arrays.asList("value1", "value2", "value3"));
+                           methodOf(this.getClass(), "stringListQueryHandler").getGenericReturnType(),
+                           message -> Arrays.asList("value1", "value2", "value3"));
 
         reactiveQueryGateway = DefaultReactorQueryGateway.builder()
-                .queryBus(queryBus)
-                .build();
+                                                         .queryBus(queryBus)
+                                                         .build();
     }
 
     @SuppressWarnings("unused") // Used by 'testSubscriptionQueryMany()' to generate query handler response type
@@ -136,8 +152,8 @@ class DefaultReactorQueryGatewayTest {
         verifyNoMoreInteractions(queryMessageHandler1);
         verifyNoMoreInteractions(queryMessageHandler2);
         StepVerifier.create(result)
-                .expectNext("handled")
-                .verifyComplete();
+                    .expectNext("handled")
+                    .verifyComplete();
         verify(queryMessageHandler1).handle(any());
     }
 
@@ -167,7 +183,6 @@ class DefaultReactorQueryGatewayTest {
 
         assertTrue(queryMessage.getMetaData().containsKey("k"));
         assertTrue(queryMessage.getMetaData().containsValue("v"));
-
     }
 
     @Test
@@ -203,8 +218,8 @@ class DefaultReactorQueryGatewayTest {
 
         List<Throwable> exceptions = new ArrayList<>(2);
         StepVerifier.create(result.onErrorContinue((t, o) -> exceptions.add(t)))
-                .expectNext("handled", "handled", "")
-                .verifyComplete();
+                    .expectNext("handled", "handled", "")
+                    .verifyComplete();
 
         assertEquals(2, exceptions.size());
         assertTrue(exceptions.get(0) instanceof RuntimeException);
@@ -217,15 +232,15 @@ class DefaultReactorQueryGatewayTest {
         int numberOfQueries = 10_000;
         Flux<QueryMessage<?, ?>> queries = Flux
                 .fromStream(IntStream.range(0, numberOfQueries)
-                        .mapToObj(i -> new GenericQueryMessage<>("backpressure",
-                                ResponseTypes.instanceOf(String.class))));
+                                     .mapToObj(i -> new GenericQueryMessage<>("backpressure",
+                                                                              ResponseTypes.instanceOf(String.class))));
         List<Integer> expectedResults = IntStream.range(1, numberOfQueries + 1)
-                .boxed()
-                .collect(Collectors.toList());
+                                                 .boxed()
+                                                 .collect(Collectors.toList());
         Flux<Object> result = reactiveQueryGateway.query(queries);
         StepVerifier.create(result)
-                .expectNext(expectedResults.toArray(new Integer[0]))
-                .verifyComplete();
+                    .expectNext(expectedResults.toArray(new Integer[0]))
+                    .verifyComplete();
         verify(queryMessageHandler1, times(numberOfQueries)).handle(any());
     }
 
@@ -233,8 +248,8 @@ class DefaultReactorQueryGatewayTest {
     void testQueryReturningNull() {
         assertNull(reactiveQueryGateway.query(0L, String.class).block());
         StepVerifier.create(reactiveQueryGateway.query(0L, String.class))
-                .expectComplete()
-                .verify();
+                    .expectComplete()
+                    .verify();
     }
 
     @Test
@@ -247,26 +262,26 @@ class DefaultReactorQueryGatewayTest {
                         .map(query -> query.andMetaData(Collections.singletonMap("key2", "value2"))));
 
         StepVerifier.create(reactiveQueryGateway.query(true, String.class))
-                .expectNext("value1value2")
-                .verifyComplete();
+                    .expectNext("value1value2")
+                    .verifyComplete();
 
         registration2.cancel();
 
         StepVerifier.create(reactiveQueryGateway.query(true, String.class))
-                .expectNext("value1")
-                .verifyComplete();
+                    .expectNext("value1")
+                    .verifyComplete();
     }
 
     @Test
     void testQueryWithBuilderDispatchInterceptor() {
         ReactorQueryGateway reactorQueryGateway = DefaultReactorQueryGateway.builder()
-                .queryBus(queryBus)
-                .dispatchInterceptors(queryMono -> queryMono.map(query -> query.andMetaData(Collections.singletonMap("key1", "value1"))))
-                .build();
+                                                                            .queryBus(queryBus)
+                                                                            .dispatchInterceptors(queryMono -> queryMono.map(query -> query.andMetaData(Collections.singletonMap("key1", "value1"))))
+                                                                            .build();
 
         StepVerifier.create(reactorQueryGateway.query(true, String.class))
-                .expectNext("value1")
-                .verifyComplete();
+                    .expectNext("value1")
+                    .verifyComplete();
     }
 
     @Test
@@ -276,7 +291,7 @@ class DefaultReactorQueryGatewayTest {
 
 
         StepVerifier.create(reactiveQueryGateway.query(5, Integer.class)) //throws Runtime exception by default
-                .verifyError(MockException.class);
+                    .verifyError(MockException.class);
     }
 
     @Test
@@ -307,8 +322,8 @@ class DefaultReactorQueryGatewayTest {
         verifyNoMoreInteractions(queryMessageHandler1);
         verifyNoMoreInteractions(queryMessageHandler2);
         StepVerifier.create(result)
-                .expectNext("handled-modified")
-                .verifyComplete();
+                    .expectNext("handled-modified")
+                    .verifyComplete();
         verify(queryMessageHandler1).handle(any());
     }
 
@@ -321,8 +336,8 @@ class DefaultReactorQueryGatewayTest {
         verifyNoMoreInteractions(queryMessageHandler1);
         verifyNoMoreInteractions(queryMessageHandler2);
         StepVerifier.create(result)
-                .expectComplete()
-                .verify();
+                    .expectComplete()
+                    .verify();
         verify(queryMessageHandler1).handle(any());
     }
 
@@ -333,7 +348,7 @@ class DefaultReactorQueryGatewayTest {
                     throw new RuntimeException();
                 });
         StepVerifier.create(reactiveQueryGateway.query(true, String.class))
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
     }
 
     @Test
@@ -341,13 +356,13 @@ class DefaultReactorQueryGatewayTest {
         reactiveQueryGateway
                 .registerDispatchInterceptor(queryMono -> Mono.error(new RuntimeException()));
         StepVerifier.create(reactiveQueryGateway.query(true, String.class))
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
     }
 
     @Test
     void testQueryFails() {
         StepVerifier.create(reactiveQueryGateway.query(5, Integer.class))
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
     }
 
     @Test
@@ -356,7 +371,7 @@ class DefaultReactorQueryGatewayTest {
         Mono<Integer> query = reactiveQueryGateway.query(5, Integer.class).retry(5);
 
         StepVerifier.create(query)
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
 
         verify(queryMessageHandler3, times(6)).handle(any());
     }
@@ -365,13 +380,13 @@ class DefaultReactorQueryGatewayTest {
     @Test
     void testScatterGather() throws Exception {
         Flux<String> result = reactiveQueryGateway.scatterGather("criteria",
-                ResponseTypes.instanceOf(String.class),
-                Duration.ofSeconds(1));
+                                                                 ResponseTypes.instanceOf(String.class),
+                                                                 Duration.ofSeconds(1));
         verifyNoMoreInteractions(queryMessageHandler1);
         verifyNoMoreInteractions(queryMessageHandler2);
         StepVerifier.create(result)
-                .expectNext("handled", "handled")
-                .verifyComplete();
+                    .expectNext("handled", "handled")
+                    .verifyComplete();
         verify(queryMessageHandler1).handle(any());
         verify(queryMessageHandler2).handle(any());
     }
@@ -390,8 +405,8 @@ class DefaultReactorQueryGatewayTest {
         verifyNoMoreInteractions(queryMessageHandler2);
 
         StepVerifier.create(result)
-                .expectNext("handled", "handled", "handled", "handled", "")
-                .verifyComplete();
+                    .expectNext("handled", "handled", "handled", "handled", "")
+                    .verifyComplete();
 
         verify(queryMessageHandler1, times(2)).handle(any());
         verify(queryMessageHandler2, times(2)).handle(any());
@@ -402,15 +417,15 @@ class DefaultReactorQueryGatewayTest {
         int numberOfQueries = 10_000;
         Flux<QueryMessage<?, ?>> queries = Flux
                 .fromStream(IntStream.range(0, numberOfQueries)
-                        .mapToObj(i -> new GenericQueryMessage<>("backpressure",
-                                ResponseTypes.instanceOf(String.class))));
+                                     .mapToObj(i -> new GenericQueryMessage<>("backpressure",
+                                                                              ResponseTypes.instanceOf(String.class))));
         List<Integer> expectedResults = IntStream.range(1, 2 * numberOfQueries + 1)
-                .boxed()
-                .collect(Collectors.toList());
+                                                 .boxed()
+                                                 .collect(Collectors.toList());
         Flux<Object> result = reactiveQueryGateway.scatterGather(queries, Duration.ofSeconds(1));
         StepVerifier.create(result)
-                .expectNext(expectedResults.toArray(new Integer[0]))
-                .verifyComplete();
+                    .expectNext(expectedResults.toArray(new Integer[0]))
+                    .verifyComplete();
         verify(queryMessageHandler1, times(numberOfQueries)).handle(any());
         verify(queryMessageHandler2, times(numberOfQueries)).handle(any());
     }
@@ -418,11 +433,11 @@ class DefaultReactorQueryGatewayTest {
     @Test
     void testScatterGatherReturningNull() {
         assertNull(reactiveQueryGateway.scatterGather(0L, ResponseTypes.instanceOf(String.class), Duration.ofSeconds(1))
-                .blockFirst());
+                                       .blockFirst());
         StepVerifier.create(reactiveQueryGateway
-                        .scatterGather(0L, ResponseTypes.instanceOf(String.class), Duration.ofSeconds(1)))
-                .expectNext()
-                .verifyComplete();
+                                    .scatterGather(0L, ResponseTypes.instanceOf(String.class), Duration.ofSeconds(1)))
+                    .expectNext()
+                    .verifyComplete();
     }
 
     @Test
@@ -435,15 +450,15 @@ class DefaultReactorQueryGatewayTest {
                         .map(query -> query.andMetaData(Collections.singletonMap("key2", "value2"))));
 
         StepVerifier.create(reactiveQueryGateway
-                        .scatterGather(true, ResponseTypes.instanceOf(String.class), Duration.ofSeconds(1)))
-                .expectNext("value1value2")
-                .verifyComplete();
+                                    .scatterGather(true, ResponseTypes.instanceOf(String.class), Duration.ofSeconds(1)))
+                    .expectNext("value1value2")
+                    .verifyComplete();
 
         registration2.cancel();
 
         StepVerifier.create(reactiveQueryGateway.query(true, String.class))
-                .expectNext("value1")
-                .verifyComplete();
+                    .expectNext("value1")
+                    .verifyComplete();
     }
 
     @Test
@@ -466,12 +481,12 @@ class DefaultReactorQueryGatewayTest {
         verifyNoMoreInteractions(queryMessageHandler2);
 
         StepVerifier.create(result)
-                .expectNext("handled-modified",
-                        "handled-modified",
-                        "handled-modified",
-                        "handled-modified",
-                        "handled-modified")
-                .verifyComplete();
+                    .expectNext("handled-modified",
+                                "handled-modified",
+                                "handled-modified",
+                                "handled-modified",
+                                "handled-modified")
+                    .verifyComplete();
 
         verify(queryMessageHandler1, times(2)).handle(any());
         verify(queryMessageHandler2, times(2)).handle(any());
@@ -484,8 +499,8 @@ class DefaultReactorQueryGatewayTest {
         verifyNoMoreInteractions(queryMessageHandler2);
         verifyNoMoreInteractions(queryMessageHandler3);
         StepVerifier.create(result)
-                .expectNext(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L)
-                .verifyComplete();
+                    .expectNext(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L)
+                    .verifyComplete();
         verify(queryMessageHandler4).handle(any());
     }
 
@@ -502,18 +517,18 @@ class DefaultReactorQueryGatewayTest {
         verifyNoMoreInteractions(queryMessageHandler2);
         verifyNoMoreInteractions(queryMessageHandler3);
         StepVerifier.create(result)
-                .expectNext(2L, 4L, 6L, 8L)
-                .verifyComplete();
+                    .expectNext(2L, 4L, 6L, 8L)
+                    .verifyComplete();
         verify(queryMessageHandler4).handle(any());
     }
 
     @Test
     void testQueryWithResultInterceptorModifyResultBasedOnQuery() throws Exception {
         reactiveQueryGateway.registerDispatchInterceptor(q -> q.map(it ->
-                it.andMetaData(Collections.singletonMap(
-                        "block",
-                        it.getPayload() instanceof Boolean)
-                )));
+                                                                            it.andMetaData(Collections.singletonMap(
+                                                                                    "block",
+                                                                                    it.getPayload() instanceof Boolean)
+                                                                            )));
         reactiveQueryGateway
                 .registerResultHandlerInterceptor((q, results) -> results
                         .filter(it -> !((boolean) q.getMetaData().get("block")))
@@ -531,8 +546,8 @@ class DefaultReactorQueryGatewayTest {
         verifyNoMoreInteractions(queryMessageHandler2);
 
         StepVerifier.create(result)
-                .expectNext("handled", "handled", "handled", "handled")
-                .verifyComplete();
+                    .expectNext("handled", "handled", "handled", "handled")
+                    .verifyComplete();
 
         verify(queryMessageHandler1, times(2)).handle(any());
         verify(queryMessageHandler2, times(2)).handle(any());
@@ -563,9 +578,9 @@ class DefaultReactorQueryGatewayTest {
         verifyNoMoreInteractions(queryMessageHandler2);
 
         StepVerifier.create(result)
-                .expectNext("handled", "handled", "handled", "handled")
-                .expectError(RuntimeException.class)
-                .verify();
+                    .expectNext("handled", "handled", "handled", "handled")
+                    .expectError(RuntimeException.class)
+                    .verify();
 
         verify(queryMessageHandler1, times(2)).handle(any());
         verify(queryMessageHandler2, times(2)).handle(any());
@@ -578,8 +593,8 @@ class DefaultReactorQueryGatewayTest {
                     throw new RuntimeException();
                 });
         StepVerifier.create(reactiveQueryGateway
-                        .scatterGather(true, ResponseTypes.instanceOf(String.class), Duration.ofSeconds(1)))
-                .verifyError(RuntimeException.class);
+                                    .scatterGather(true, ResponseTypes.instanceOf(String.class), Duration.ofSeconds(1)))
+                    .verifyError(RuntimeException.class);
     }
 
     @Test
@@ -587,17 +602,17 @@ class DefaultReactorQueryGatewayTest {
         reactiveQueryGateway
                 .registerDispatchInterceptor(queryMono -> Mono.error(new RuntimeException()));
         StepVerifier.create(reactiveQueryGateway
-                        .scatterGather(true, ResponseTypes.instanceOf(String.class), Duration.ofSeconds(1)))
-                .verifyError(RuntimeException.class);
+                                    .scatterGather(true, ResponseTypes.instanceOf(String.class), Duration.ofSeconds(1)))
+                    .verifyError(RuntimeException.class);
     }
 
     @Test
     void testScatterGatherFails() {
         StepVerifier.create(reactiveQueryGateway.scatterGather(6,
-                        ResponseTypes.instanceOf(Integer.class),
-                        Duration.ofSeconds(1)))
-                .expectNextCount(0)
-                .verifyComplete();
+                                                               ResponseTypes.instanceOf(Integer.class),
+                                                               Duration.ofSeconds(1)))
+                    .expectNextCount(0)
+                    .verifyComplete();
     }
 
     @Test
@@ -605,11 +620,11 @@ class DefaultReactorQueryGatewayTest {
         doThrow(new RuntimeException(":(")).when(queryBus).scatterGather(any(), anyLong(), any());
 
         Flux<Integer> query = reactiveQueryGateway.scatterGather(6,
-                ResponseTypes.instanceOf(Integer.class),
-                Duration.ofSeconds(1)).retry(5);
+                                                                 ResponseTypes.instanceOf(Integer.class),
+                                                                 Duration.ofSeconds(1)).retry(5);
 
         StepVerifier.create(query)
-                .verifyError();
+                    .verifyError();
 
 
         verify(queryBus, times(6)).scatterGather(any(), anyLong(), any());
@@ -619,23 +634,23 @@ class DefaultReactorQueryGatewayTest {
     @Test
     void testSubscriptionQuery() throws Exception {
         Mono<SubscriptionQueryResult<String, String>> monoResult = reactiveQueryGateway.subscriptionQuery("criteria",
-                String.class,
-                String.class);
+                                                                                                          String.class,
+                                                                                                          String.class);
         verifyNoMoreInteractions(queryMessageHandler1);
         verifyNoMoreInteractions(queryMessageHandler2);
 
         SubscriptionQueryResult<String, String> result = monoResult.block();
         assertNotNull(result);
         StepVerifier.create(result.initialResult())
-                .expectNext("handled")
-                .verifyComplete();
+                    .expectNext("handled")
+                    .verifyComplete();
         StepVerifier.create(result.updates()
-                        .doOnSubscribe(s -> {
-                            queryUpdateEmitter.emit(String.class, q -> true, "update");
-                            queryUpdateEmitter.complete(String.class, q -> true);
-                        }))
-                .expectNext("update")
-                .verifyComplete();
+                                  .doOnSubscribe(s -> {
+                                      queryUpdateEmitter.emit(String.class, q -> true, "update");
+                                      queryUpdateEmitter.complete(String.class, q -> true);
+                                  }))
+                    .expectNext("update")
+                    .verifyComplete();
         verify(queryMessageHandler1).handle(any());
     }
 
@@ -643,11 +658,11 @@ class DefaultReactorQueryGatewayTest {
     void testMultipleSubscriptionQueries() throws Exception {
         Flux<SubscriptionQueryMessage<?, ?, ?>> queries = Flux.fromIterable(Arrays.asList(
                 new GenericSubscriptionQueryMessage<>("query1",
-                        ResponseTypes.instanceOf(String.class),
-                        ResponseTypes.instanceOf(String.class)),
+                                                      ResponseTypes.instanceOf(String.class),
+                                                      ResponseTypes.instanceOf(String.class)),
                 new GenericSubscriptionQueryMessage<>(4,
-                        ResponseTypes.instanceOf(Integer.class),
-                        ResponseTypes.instanceOf(String.class))));
+                                                      ResponseTypes.instanceOf(Integer.class),
+                                                      ResponseTypes.instanceOf(String.class))));
 
         Flux<SubscriptionQueryResult<?, ?>> result = reactiveQueryGateway.subscriptionQuery(queries);
         verifyNoMoreInteractions(queryMessageHandler1);
@@ -657,10 +672,10 @@ class DefaultReactorQueryGatewayTest {
         result.subscribe(sqr -> initialResults.add((Mono<Object>) sqr.initialResult()));
         assertEquals(2, initialResults.size());
         StepVerifier.create(initialResults.get(0))
-                .expectNext("handled")
-                .verifyComplete();
+                    .expectNext("handled")
+                    .verifyComplete();
         StepVerifier.create(initialResults.get(1))
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
 
         verify(queryMessageHandler1).handle(any());
     }
@@ -670,14 +685,14 @@ class DefaultReactorQueryGatewayTest {
         int numberOfQueries = 10_000;
         Flux<SubscriptionQueryMessage<?, ?, ?>> queries = Flux
                 .fromStream(IntStream.range(0, numberOfQueries)
-                        .mapToObj(i -> new GenericSubscriptionQueryMessage<>("backpressure",
-                                ResponseTypes
-                                        .instanceOf(String.class),
-                                ResponseTypes
-                                        .instanceOf(String.class))));
+                                     .mapToObj(i -> new GenericSubscriptionQueryMessage<>("backpressure",
+                                                                                          ResponseTypes
+                                                                                                  .instanceOf(String.class),
+                                                                                          ResponseTypes
+                                                                                                  .instanceOf(String.class))));
         List<Integer> expectedResults = IntStream.range(1, numberOfQueries + 1)
-                .boxed()
-                .collect(Collectors.toList());
+                                                 .boxed()
+                                                 .collect(Collectors.toList());
         Flux<SubscriptionQueryResult<?, ?>> result = reactiveQueryGateway.subscriptionQuery(queries);
         List<Mono<Object>> initialResults = new ArrayList<>(numberOfQueries);
         //noinspection unchecked
@@ -685,8 +700,8 @@ class DefaultReactorQueryGatewayTest {
         assertEquals(numberOfQueries, initialResults.size());
         for (int i = 0; i < numberOfQueries; i++) {
             StepVerifier.create(initialResults.get(i))
-                    .expectNext(expectedResults.get(i))
-                    .verifyComplete();
+                        .expectNext(expectedResults.get(i))
+                        .verifyComplete();
         }
 
         verify(queryMessageHandler1, times(numberOfQueries)).handle(any());
@@ -695,21 +710,21 @@ class DefaultReactorQueryGatewayTest {
     @Test
     void testSubscriptionQueryReturningNull() {
         SubscriptionQueryResult<String, String> result = reactiveQueryGateway.subscriptionQuery(0L,
-                        String.class,
-                        String.class)
-                .block();
+                                                                                                String.class,
+                                                                                                String.class)
+                                                                             .block();
         assertNotNull(result);
         assertNull(result.initialResult().block());
         StepVerifier.create(result.initialResult())
-                .expectNext()
-                .verifyComplete();
+                    .expectNext()
+                    .verifyComplete();
         StepVerifier.create(result.updates()
-                        .doOnSubscribe(s -> {
-                            queryUpdateEmitter.emit(Long.class, q -> true, (String) null);
-                            queryUpdateEmitter.complete(Long.class, q -> true);
-                        }))
-                .expectNext()
-                .verifyComplete();
+                                  .doOnSubscribe(s -> {
+                                      queryUpdateEmitter.emit(Long.class, q -> true, (String) null);
+                                      queryUpdateEmitter.complete(Long.class, q -> true);
+                                  }))
+                    .expectNext()
+                    .verifyComplete();
     }
 
     @Test
@@ -726,8 +741,8 @@ class DefaultReactorQueryGatewayTest {
         SubscriptionQueryResult<String, String> result = monoResult.block();
         assertNotNull(result);
         StepVerifier.create(result.initialResult())
-                .expectNext("value1value2")
-                .verifyComplete();
+                    .expectNext("value1value2")
+                    .verifyComplete();
 
         registration2.cancel();
 
@@ -735,8 +750,8 @@ class DefaultReactorQueryGatewayTest {
         result = monoResult.block();
         assertNotNull(result);
         StepVerifier.create(result.initialResult())
-                .expectNext("value1")
-                .verifyComplete();
+                    .expectNext("value1")
+                    .verifyComplete();
     }
 
     @Test
@@ -746,7 +761,7 @@ class DefaultReactorQueryGatewayTest {
                     throw new RuntimeException();
                 });
         StepVerifier.create(reactiveQueryGateway.subscriptionQuery(true, String.class, String.class))
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
     }
 
     @Test
@@ -754,18 +769,18 @@ class DefaultReactorQueryGatewayTest {
         reactiveQueryGateway
                 .registerDispatchInterceptor(queryMono -> Mono.error(new RuntimeException()));
         StepVerifier.create(reactiveQueryGateway.subscriptionQuery(true, String.class, String.class))
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
     }
 
     @Test
     void testSubscriptionQueryFails() {
         Mono<SubscriptionQueryResult<Integer, Integer>> monoResult = reactiveQueryGateway.subscriptionQuery(6,
-                Integer.class,
-                Integer.class);
+                                                                                                            Integer.class,
+                                                                                                            Integer.class);
         SubscriptionQueryResult<Integer, Integer> result = monoResult.block();
         assertNotNull(result);
         StepVerifier.create(result.initialResult())
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
     }
 
     @Test
@@ -774,12 +789,12 @@ class DefaultReactorQueryGatewayTest {
         doThrow(new RuntimeException(":(")).when(queryBus).subscriptionQuery(any(), any(), anyInt());
 
         Mono<SubscriptionQueryResult<Integer, Integer>> monoResult = reactiveQueryGateway.subscriptionQuery(6,
-                        Integer.class,
-                        Integer.class)
-                .retry(5);
+                                                                                                            Integer.class,
+                                                                                                            Integer.class)
+                                                                                         .retry(5);
 
         StepVerifier.create(monoResult)
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
 
         verify(queryBus, times(6)).subscriptionQuery(any(), any(), anyInt());
     }
@@ -787,13 +802,13 @@ class DefaultReactorQueryGatewayTest {
     @Test
     void testSubscriptionQueryFailsRetryInitialResult() throws Exception {
         Mono<SubscriptionQueryResult<Integer, Integer>> monoResult = reactiveQueryGateway.subscriptionQuery(6,
-                Integer.class,
-                Integer.class);
+                                                                                                            Integer.class,
+                                                                                                            Integer.class);
 
         SubscriptionQueryResult<Integer, Integer> result = monoResult.block();
         assertNotNull(result);
         StepVerifier.create(result.initialResult().retry(5))
-                .verifyError(RuntimeException.class);
+                    .verifyError(RuntimeException.class);
 
         verify(queryMessageHandler3, times(6)).handle(any());
     }
@@ -818,9 +833,9 @@ class DefaultReactorQueryGatewayTest {
             queryUpdateEmitter.complete(String.class, q -> true);
         });
         StepVerifier.create(result.doOnNext(s -> countDownLatch.countDown()))
-                .expectNext("handled")
-                .expectNext("1", "2", "3", "4", "5")
-                .verifyComplete();
+                    .expectNext("handled")
+                    .expectNext("1", "2", "3", "4", "5")
+                    .verifyComplete();
     }
 
     @Test
@@ -837,11 +852,11 @@ class DefaultReactorQueryGatewayTest {
 
             return result;
         }).when(queryBus)
-                .subscriptionQuery(any(), any(), anyInt());
+          .subscriptionQuery(any(), any(), anyInt());
 
         StepVerifier.create(reactiveQueryGateway.queryUpdates("6", String.class))
-                .expectNext("1", "2", "3", "4", "5")
-                .verifyComplete();
+                    .expectNext("1", "2", "3", "4", "5")
+                    .verifyComplete();
     }
 
     @Test
@@ -858,14 +873,15 @@ class DefaultReactorQueryGatewayTest {
 
             return result;
         }).when(queryBus)
-                .subscriptionQuery(any(), any(), anyInt());
+          .subscriptionQuery(any(), any(), anyInt());
 
         StepVerifier.create(reactiveQueryGateway.subscriptionQueryMany(2.3, String.class))
-                .expectNext("value1", "value2", "value3", "update1", "update2", "update3", "update4", "update5")
-                .verifyComplete();
+                    .expectNext("value1", "value2", "value3", "update1", "update2", "update3", "update4", "update5")
+                    .verifyComplete();
     }
 
     private static class MockException extends RuntimeException {
+
     }
 
     ;

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <axon.version>4.6.1</axon.version>
-        <projectreactor.version>3.4.24</projectreactor.version>
+        <axon.version>4.6.3</axon.version>
+        <projectreactor.version>3.5.2</projectreactor.version>
 
-        <spring.version>5.3.23</spring.version>
-        <spring.boot.version>2.7.5</spring.boot.version>
+        <spring.version>5.3.25</spring.version>
+        <spring.boot.version>2.7.7</spring.boot.version>
 
         <slf4j.version>1.7.28</slf4j.version>
         <log4j.version>2.13.0</log4j.version>


### PR DESCRIPTION
In the tests, some deprecated methods were used that are now removed. they have been changed. Also, the context now always also contains another key, so the context tests have been made less strict.

It also adds copyright notices and moves the Axon, Spring, and Spring Boot dependencies to the latest patch versions.
