### PR TITLE
Enable provisioning a `Message` with custom `MetaData` for `ReactorQueryGateway#subscriptionQuery`

### DIFF
--- a/axon-reactor/src/main/java/org/axonframework/extensions/reactor/queryhandling/gateway/DefaultReactorQueryGateway.java
+++ b/axon-reactor/src/main/java/org/axonframework/extensions/reactor/queryhandling/gateway/DefaultReactorQueryGateway.java
@@ -20,6 +20,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.Registration;
 import org.axonframework.extensions.reactor.messaging.ReactorMessageDispatchInterceptor;
 import org.axonframework.extensions.reactor.messaging.ReactorResultHandlerInterceptor;
+import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.ResultMessage;
 import org.axonframework.messaging.responsetypes.ResponseType;
@@ -165,9 +166,9 @@ public class DefaultReactorQueryGateway implements ReactorQueryGateway {
                                                                            int updateBufferSize) {
 
         //noinspection unchecked
-        return Mono.<QueryMessage<?, ?>>fromCallable(() -> new GenericSubscriptionQueryMessage<>(query,
-                                                                                                 initialResponseType,
-                                                                                                 updateResponseType))
+        return Mono.<QueryMessage<?, ?>>fromCallable(() -> new GenericSubscriptionQueryMessage<>(
+                           GenericMessage.asMessage(query), queryName, initialResponseType, updateResponseType)
+                   )
                    .transform(this::processDispatchInterceptors)
                    .map(interceptedQuery -> (SubscriptionQueryMessage<Q, U, I>) interceptedQuery)
                    .flatMap(isq -> dispatchSubscriptionQuery(isq, backpressure, updateBufferSize))


### PR DESCRIPTION
The subscription query operation on the `ReactorQueryGateway` did not take into account that you may want to provide a `Message` instead of an `Object`.
The specific use case is to be able to provide custom `MetaData` for specific gateway operations.
As we support this throughout the other gateways, it's only feasible that `ReactorQueryGateway#subscriptionQuery` supports it too.