### PR TITLE
Move old docs 2 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ For more information on anything Axon, please visit our website, [http://axoniq.
 
 ## Getting started
 
-The [reference guide](https://docs.axoniq.io) contains a separate chapter for all the extensions.
-The Reactor extension description can be found [here](https://docs.axoniq.io/reference-guide/extensions/reactor).
+The [AxonIQ Library](https://library.axoniq.io) contains a section for the guides of all the Axon Framework extensions.
+The Reactor extension guide can be found [here](https://library.axoniq.io/home/guides/axon-framework.html).
 
 ## Receiving help
 
@@ -30,10 +30,10 @@ Are you having trouble using the extension?
 We'd like to help you out the best we can!
 There are a couple of things to consider when you're traversing anything Axon:
 
-* Checking the [reference guide](https://docs.axoniq.io/reference-guide/extensions/reactor) should be your first stop,
- as the majority of possible scenarios you might encounter when using Axon should be covered there.
+* Checking the [reference guide](https://library.axoniq.io/axon_framework_old_ref/) should be your first stop,
+  as the majority of possible scenarios you might encounter when using Axon should be covered there.
 * If the Reference Guide does not cover a specific topic you would've expected,
- we'd appreciate if you could file an [issue](https://github.com/AxonIQ/reference-guide/issues) about it for us. 
+  we'd appreciate if you could post a [new thread/topic on our library fourms describing the problem](https://discuss.axoniq.io/c/26).
 * There is a [forum](https://discuss.axoniq.io/) to support you in the case the reference guide did not sufficiently answer your question.
 Axon Framework and Server developers will help out on a best effort basis.
 Know that any support from contributors on posted question is very much appreciated on the forum.

--- a/docs/_playbook/.gitignore
+++ b/docs/_playbook/.gitignore
@@ -1,0 +1,5 @@
+build
+node_modules
+.vscode
+vale
+package-lock.json

--- a/docs/_playbook/.vale.ini
+++ b/docs/_playbook/.vale.ini
@@ -1,0 +1,24 @@
+StylesPath = vale
+
+MinAlertLevel = suggestion
+
+Packages = http://github.com/AxonIQ/axoniq-vale-package/releases/latest/download/axoniq-vale-package.zip
+
+Vocab = general, AxonIQ, Java, Names_Terms, misc
+
+[*.{adoc,html}]
+BasedOnStyles = AxonIQ, proselint, Google
+
+Google.Headings = NO # Diasable in favor od AxonIQ one
+Google.Parens = NO # Disable warning about using parens
+Google.Quotes = NO # Diasable "commas and periods go inside quotation marks"
+Google.WordList = NO # Disable Google's word list
+Google.Passive = NO # Allow the use of Passive voice
+Google.Colons = NO # Allow the use of Colons
+Google.Will = NO # Allow use will
+Google.Contractions = NO
+Google.We = NO
+
+
+AxonIQ.AcronymCase = NO
+AxonIQ.HeadingTitle = NO

--- a/docs/_playbook/package.json
+++ b/docs/_playbook/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "@antora/atlas-extension": "^1.0.0-alpha.2",
+    "@antora/cli": "^3.2.0-alpha.2",
+    "@antora/lunr-extension": "^1.0.0-alpha.8",
+    "@antora/site-generator": "^3.2.0-alpha.2",
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "@axoniq/antora-vale-extension": "^0.1.1",
+    "asciidoctor-kroki": "^0.17.0"
+  }
+}

--- a/docs/_playbook/playbook.yaml
+++ b/docs/_playbook/playbook.yaml
@@ -1,0 +1,42 @@
+site:
+  title: Reactor Extension docs PREVIEW
+  start_page: reactor_extension_old_ref::index.adoc
+
+content:
+  sources:
+  - url: ../..
+    start_paths: ['docs/*', '!docs/_*']
+
+asciidoc:
+  attributes:
+    experimental: true
+    page-pagination: true
+    kroki-fetch-diagram: true
+  #   primary-site-manifest-url: https://library.axoniq.io/site-manifest.json
+  extensions:
+    - asciidoctor-kroki
+    - '@asciidoctor/tabs'
+
+antora:
+  extensions:
+    - id: prose-linting
+      require: '@axoniq/antora-vale-extension'
+      enabled: true
+      vale_config: .vale.ini
+      update_styles: true
+    - id: lunr
+      require: '@antora/lunr-extension'
+      enabled: true
+      index_latest_only: true
+    - id: atlas
+      require: '@antora/atlas-extension'
+
+runtime:
+  fetch: true # fetch remote repos
+  log:
+    level: info
+    failure_level: error
+
+ui:
+  bundle:
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.0.1.10/ui-bundle.zip

--- a/docs/old-reference-guide/antora.yml
+++ b/docs/old-reference-guide/antora.yml
@@ -1,0 +1,14 @@
+name: reactor_extension_old_ref
+title: Reactor Extension Guide
+version: true
+prerelease: true
+start_page: ROOT:index.adoc
+
+asciidoc:
+  attributes:
+    component_description: The Reactor Extension guide from the former reference guide
+    type: guide
+    group: axon-framework
+
+nav:
+  - modules/nav.adoc

--- a/docs/old-reference-guide/modules/ROOT/pages/index.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/index.adoc
@@ -1,0 +1,14 @@
+:navtitle: Reactor Extension
+= Reactor
+
+Overlooking Axon Frameworks architecture, you can notice that in general systems using the framework are "Message Driven", "Responsive", "Resilient" and "Elastic". According to link:https://www.reactivemanifesto.org/[Reactive Manifesto,window=_blank,role=external], the same holds for Reactive Systems in general.
+
+Although we can state that Axon Framework is a type of reactive system, we can't say that it is fully reactive.
+
+NOTE: Reactive programming is an approach to writing software that embraces asynchronous I/O. Asynchronous I/O is a small idea that portends big changes for software. The idea is simple: alleviate inefficient resource utilization by reclaiming resources that would otherwise be idle, as they waited for I/O activity. Asynchronous I/O inverts the normal design I/O processing: the clients are notified of new data instead of asking for it, which frees the client to do other work while waiting for these notifications.
+
+By their nature, a reactive API and Axon are a great fit, as most of framework's operations are async and non-blocking. Providing a dedicated extension for this was thus a logical step to take. To that end, we chose to use Pivotal’s link:https://projectreactor.io/[Project Reactor,window=_blank,role=external] to build this extension. Reactor builds on top of the link:https://www.reactive-streams.org/[Reactive Streams specification,window=_blank,role=external] and is the de-facto standard for Java enterprise and Spring applications. As such, we feel it to be a great fit to provide an extension in, making Axon more reactive.
+
+NOTE: Not all Axon components offer a reactive API, yet. We will incrementally introduce more "reactiveness" to this extension, giving priority to components where users can benefit the most.
+
+To use the link:https://github.com/AxonFramework/extension-reactor[Axon Reactor Extension,window=_blank,role=external], make sure that `axon-reactor` module is available on the classpath.

--- a/docs/old-reference-guide/modules/ROOT/pages/reactor-gateways.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/reactor-gateways.adoc
@@ -1,0 +1,404 @@
+:navtitle: Reactor Gateways
+= Reactor Gateways
+
+The "Reactive Gateways" offer a reactive API wrapper around the command, query and event bus. Most of the operations are similar to those from non-reactive gateways, simply replacing the `CompletableFuture` with either a `Mono` or `Flux`. In some cases, the API is expended to ease use of common reactive patterns.
+
+WARNING: Reactor doesn't allow `null` values in streams. Any `null` value returned from the handler will be mapped to link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#empty[`Mono#empty()`,window=_blank,role=external].
+
+[NOTE]
+.Retrying operations
+====
+All operations support Reactor's retry mechanism:
+
+[source,java]
+----
+reactiveQueryGateway.query(query, ResponseType.class).retry(5);
+----
+This call will retry sending the query a maximum of five times when it fails.
+====
+
+== Configuration in SpringBoot
+
+This extension can be added as a Spring Boot starter dependency to your project using group id `org.axonframework.extensions.reactor` and artifact id `axon-reactor-spring-boot-starter`. The implementation of the extension can be found link:https://github.com/AxonFramework/extension-reactor[here,window=_blank,role=external].
+
+== Reactor command gateway
+
+This section describes the methods on the `ReactorCommandGateway`.
+
+[[send]]
+=== `send`
+Sends the given command once the caller subscribes to the command result. Returns immediately.
+
+A common pattern is using the REST API to send a command. In this case it is recommend to for example use link:https://docs.spring.io/spring-framework/docs/5.0.0.BUILD-SNAPSHOT/spring-framework-reference/html/web-reactive.html[WebFlux,window=_blank,role=external], and return the command result `Mono` directly to the controller:
+
+[source,java]
+.Sending a command from a Spring WebFlux Controller.
+----
+class SpringCommandController {
+
+    private final ReactorCommandGateway reactiveCommandGateway;
+
+    @PostMapping
+    public Mono<CommandHandlerResponseBody> sendCommand(@RequestBody CommandBody command) {
+        return reactiveCommandGateway.send(command);
+    }
+}
+----
+
+WARNING: If the command handling function returns type `void`, `Mono<CommandHandlerResponseBody>` should be replaced with `Mono<Void>`
+
+Another common pattern is "send and forget":
+
+[source,java]
+.Function that sends a command and returns immediately without waiting for the result.
+----
+class CommandDispatcher {
+
+    private final ReactorCommandGateway reactiveCommandGateway;
+
+    public void sendAndForget(MyCommand command) {
+         reactiveCommandGateway.send(command)
+                               .subscribe();
+    }
+}
+----
+
+[[sendall]]
+=== `sendAll`
+
+This method uses the given `Publisher` of commands to dispatch incoming commands.
+
+WARNING: This operation is available only in the Reactor extension. Use it to connect third-party streams that delivers commands.
+
+[source,java]
+.Connects an external input stream directly to the Reactor Command Gateway.
+----
+class CommandPublisher {
+
+    private final ReactorCommandGateway reactiveCommandGateway;
+
+    @PostConstruct
+    public void startReceivingCommands(Flux<CommandBody> inputStream) {
+        reactiveCommandGateway.sendAll(inputStream)
+                              .subscribe();
+    }
+}
+----
+
+NOTE: The sendAll operation will keep sending commands until the input stream is canceled.
+
+WARNING: `send` and `sendAll` do not offer _any_ backpressure, yet. The only backpressure mechanism in place is that commands will be sent sequentially; thus once the result of a previous command arrives. The number of commands is prefetched from an incoming stream and stored in a buffer for sending (see link:https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#concatMap[`Flux#concatMap`,window=_blank,role=external]). *This slows down sending*, but does not guarantee that the `Subscriber` will not be overwhelmed with commands if they are sent too fast.
+
+== Reactor query gateway
+
+[[query]]
+=== `query`
+
+Sends the given `query`, expecting a response in the form of `responseType` from a single source.
+
+[source,java]
+.Recommended way of using the Reactor query gateway within a Spring REST controller.
+----
+class SpringQueryController {
+
+    private final ReactorQueryGateway reactiveQueryGateway;
+
+    // The query's Mono is returned to the Spring controller. Subscribe control is given to Spring Framework.
+    @GetMapping
+    public Mono<SomeResponseType> findAll(FindAllQuery query, Class<SomeResponseType> responseType) {
+        return reactiveQueryGateway.query(query, responseType);
+    }
+}
+----
+
+[[scattergather]]
+=== `scatterGather`
+Sends the given `query`, expecting a response in the form of `responseType` from several sources within a specified `duration`.
+
+[source,java]
+.Sends a given query that stops after receiving three results, or after 5 seconds.
+----
+class SpringQueryController {
+
+    private final ReactorQueryGateway reactiveQueryGateway;
+
+    @GetMapping
+    public Flux<SomeResponseType> findMany(FindManyQuery query) {
+        return reactiveQueryGateway.scatterGather(query, SomeResponseType.class, Duration.ofSeconds(5)).take(3);
+    }
+}
+----
+
+=== Subscription queries
+
+Firstly, the Reactor API for subscription queries in Axon is not new.
+
+However, we noticed several patterns which are often used, such as:
+
+- Concatenating initial results with query updates in a single stream, or
+- skipping the initial result all together.
+
+As such, the Reactor Extension provides several methods to ease usage of these common patterns.
+
+[[subscriptionquery]]
+==== `subscriptionQuery`
+Sends the given `query`, returns the initial result and keeps streaming incremental updates until a subscriber unsubscribes from the `Flux`.
+
+Note that this method should be used when the response type of the initial result and incremental update match.
+
+[source,java]
+----
+Flux<ResultType> resultFlux = reactiveQueryGateway.subscriptionQuery("criteriaQuery", ResultType.class);
+----
+
+The above invocation through the `ReactorQueryGateway` is equivalent to:
+
+[source,java]
+----
+class SubscriptionQuerySender {
+
+    private final ReactorQueryGateway reactiveQueryGateway;
+
+    public Flux<SomeResponseType> sendSubscriptionQuery(SomeQuery query, Class<SomeResponseType> responseType) {
+        return reactiveQueryGateway.subscriptionQuery(query, responseType, responseType)
+                                   .flatMapMany(result -> result.initialResult()
+                                                                .concatWith(result.updates())
+                                                                .doFinally(signal -> result.close()));
+    }
+}
+----
+
+[[subscriptionquerymany]]
+==== `subscriptionQueryMany`
+
+Sends the given `query`, returns the initial result and keeps streaming incremental updates until a subscriber unsubscribes from the `Flux`.
+
+This operation should be used when the initial result contains multiple instances of the response type which needs to be flattened. Additionally, the response type of the initial response and incremental updates need to match.
+
+[source,java]
+----
+Flux<ResultType> resultFlux = reactiveQueryGateway.subscriptionQueryMany("criteriaQuery", ResultType.class);
+----
+
+The above invocation through the `ReactorQueryGateway` is equivalent to:
+
+[source,java]
+----
+class SubscriptionQuerySender {
+
+    private final ReactorQueryGateway reactiveQueryGateway;
+
+    public Flux<SomeResponseType> sendSubscriptionQuery(SomeQuery query, Class<SomeResponseType> responseType) {
+        return reactiveQueryGateway.subscriptionQuery(query,
+                                                      ResponseTypes.multipleInstancesOf(responseType),
+                                                      ResponseTypes.instanceOf(responseType))
+                                   .flatMapMany(result -> result.initialResult()
+                                                                .flatMapMany(Flux::fromIterable)
+                                                                .concatWith(result.updates())
+                                                                .doFinally(signal -> result.close()));
+    }
+}
+----
+
+[[queryupdated]]
+==== `queryUpdates`
+Sends the given `query` and streams incremental updates until a subscriber unsubscribes from the `Flux`.
+
+This method could be used when subscriber is only interested in updates.
+
+[source,java]
+----
+Flux<ResultType> updatesOnly = reactiveQueryGateway.queryUpdates("criteriaQuery", ResultType.class);
+----
+
+The above invocation through the ReactorQueryGateway is equivalent to:
+
+[source,java]
+----
+class SubscriptionQuerySender {
+
+    private final ReactorQueryGateway reactiveQueryGateway;
+
+    public Flux<SomeResponseType> sendSubscriptionQuery(SomeQuery query, Class<SomeResponseType> responseType) {
+        return reactiveQueryGateway.subscriptionQuery(query, ResponseTypes.instanceOf(Void.class), responseType)
+                                   .flatMapMany(result -> result.updates()
+                                                                .doFinally(signal -> result.close()));
+    }
+}
+----
+
+WARNING: In the above shown methods, the subscription query is closed automatically after a subscriber has unsubscribed from the `Flux`. When using the regular `QueryGateway`, the subscription query needs to be closed manually however.
+
+== Reactor event gateway
+
+Reactive variation of the `EventGateway`. Provides support for reactive return types such as `Flux`.
+
+[[publish]]
+=== `publish`
+Publishes the given `events` once the caller subscribes to the resulting `Flux`.
+
+This method returns events that were published. Note that the returned events may be different from those the user has published, granted an xref:_interceptors[interceptor] has been registered which modifies events.
+
+[source,java]
+.Example of dispatcher modified events, returned to user as the result `Flux`.
+----
+class EventPublisher {
+
+    private final ReactorEventGateway reactiveEventGateway;
+
+    // Register a dispatch interceptor to modify the event messages
+    public EventPublisher() {
+        reactiveEventGateway.registerDispatchInterceptor(
+            eventMono -> eventMono.map(event -> GenericEventMessage.asEventMessage("intercepted" + event.getPayload()))
+        );
+    }
+
+    public void publishEvent() {
+        Flux<Object> result = reactiveEventGateway.publish("event");
+    }
+}
+----
+
+== Interceptors
+
+Axon provides a notion of xref:axon_framework_old_ref:messaging-concepts:message-intercepting.adoc[interceptors]. The Reactor gateways allow for similar interceptor logic, namely the `ReactorMessageDispatchInterceptor` and `ReactorResultHandlerInterceptor`.
+
+These interceptors allow us to centrally define rules and filters that will be applied to a message stream.
+
+NOTE: Interceptors will be applied in order they have been registered to the given component.
+
+=== React dispatch interceptors
+
+The `ReactorMessageDispatchInterceptor` should be used to centrally apply rules and validations for outgoing messages. Note that a `ReactorMessageDispatchInterceptor` is an implementation of the default `MessageDispatchInterceptor` interface used throughout the framework. The implementation of this interface is described as follows:
+
+[source,java]
+----
+@FunctionalInterface
+public interface ReactorMessageDispatchInterceptor<M extends Message<?>> extends MessageDispatchInterceptor<M> {
+
+    Mono<M> intercept(Mono<M> message);
+
+    @Override
+    default BiFunction<Integer, M, M> handle(List<? extends M> messages) {
+        return (position, message) -> intercept(Mono.just(message)).block();
+    }
+}
+----
+
+It thus defaults the `MessageDispatchInterceptor#handle(List<? extends M>` method to utilize the `ReactorMessageDispatchInterceptor#intercept(Mono<M>`) method. As such, a `ReactorMessageDispatchInterceptor` could thus be configured on a plain Axon gateway too. Here are a couple of examples how a message dispatch interceptor could be used:
+
+[source,java]
+.Dispatch interceptor that adds key-value pairs to the message's `MetaData`.
+----
+class ReactorConfiguration {
+
+    public void registerDispatchInterceptor(ReactorCommandGateway reactiveGateway) {
+        reactiveGateway.registerDispatchInterceptor(
+            msgMono -> msgMono.map(msg -> msg.andMetaData(Collections.singletonMap("key1", "value1")))
+        );
+    }
+}
+----
+
+[source,java]
+.Dispatch interceptor that discards the message, based on a security flag in the Reactor Context.
+----
+class ReactorConfiguration {
+
+    public void registerDispatchInterceptor(ReactorEventGateway reactiveGateway) {
+        reactiveGateway.registerDispatchInterceptor(
+            msgMono -> msgMono.filterWhen(v -> Mono.subscriberContext()
+                              .filter(ctx-> ctx.hasKey("security"))
+                              .map(ctx->ctx.get("security")))
+        );
+    }
+}
+----
+
+=== Reactor result handler interceptors
+
+The `ReactorResultHandlerInterceptor` should be used to centrally apply rules and validations for incoming messages, a.k.a. results. The implementation of this interface is described as follows:
+
+[source,java]
+----
+@FunctionalInterface
+public interface ReactorResultHandlerInterceptor<M extends Message<?>, R extends ResultMessage<?>> {
+
+    Flux<R> intercept(M message, Flux<R> results);
+}
+----
+
+The parameters are the `message` that has been sent, and a `Flux` of `results` from that message, which is going to be intercepted. The `message` parameter can be useful if you want to apply a given result rule only for specific messages. Here are a couple of examples how a message result interceptor could be used:
+
+NOTE: This type of interceptor is available _only_ in the Reactor Extension.
+
+[source,java]
+.Result interceptor which discards all results that have a payload matching `blockedPayload`
+----
+class ReactorConfiguration {
+
+    public void registerResultInterceptor(ReactorQueryGateway reactiveGateway) {
+        reactiveGateway.registerResultHandlerInterceptor(
+            (msg, results) -> results.filter(r -> !r.getPayload().equals("blockedPayload"))
+        );
+    }
+}
+----
+
+[source,java]
+.Result interceptor which validates that the query result does not contain an empty `String`.
+----
+class ReactorConfiguration {
+
+    public void registerResultInterceptor(ReactorQueryGateway reactiveGateway) {
+        reactiveQueryGateway.registerResultHandlerInterceptor(
+            (query, results) -> results.flatMap(r -> {
+                if (r.getPayload().equals("")) {
+                    return Flux.<ResultMessage<?>>error(new RuntimeException("no empty strings allowed"));
+                } else {
+                    return Flux.just(r);
+                }
+            })
+        );
+    }
+}
+----
+
+[source,java]
+.Result interceptor which discards all results where the `queryName` matches `myBlockedQuery`.
+----
+class ReactorConfiguration {
+
+    public void registerResultInterceptor(ReactorQueryGateway reactiveGateway) {
+        reactiveQueryGateway.registerResultHandlerInterceptor(
+            (q, results) -> results.filter(it -> !((boolean) q.getQueryName().equals("myBlockedQuery")))
+        );
+    }
+}
+----
+
+[source,java]
+.Result interceptor which limits the result waiting time to thirty seconds per message.
+----
+class ReactorConfiguration {
+
+    public void registerResultInterceptor(ReactorCommandGateway reactiveGateway) {
+        reactiveGateway.registerResultHandlerInterceptor(
+            (msg,results) -> results.timeout(Duration.ofSeconds(30))
+        );
+    }
+}
+----
+
+[source,java]
+.Result interceptor which limits the number of results to five entries, and logs all results.
+----
+class ReactorConfiguration {
+
+    public void registerResultInterceptor(ReactorCommandGateway reactiveGateway) {
+        reactiveGateway.registerResultHandlerInterceptor(
+            (msg,results) -> results.log().take(5)
+        );
+    }
+}
+----

--- a/docs/old-reference-guide/modules/nav.adoc
+++ b/docs/old-reference-guide/modules/nav.adoc
@@ -1,0 +1,2 @@
+* xref::index.adoc[]
+** xref::reactor-gateways.adoc[]


### PR DESCRIPTION
Contents from the Reactor extension docs in the old reference guide have been moved here to be published with antora at library.axoniq.io > Guides > Axon Framework guides